### PR TITLE
Fix to move to className from cssClass

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-platform-css",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "A NativeScript plugin to deal with Declarative UI and Platform CSS",
   "main": "platformcss.js",
   "nativescript": {

--- a/platformcss.js
+++ b/platformcss.js
@@ -71,11 +71,11 @@ const setDevice = function(args) {
     }
 
     if (currentPage) {
-        const data = currentPage.cssClass || '';
+        const data = currentPage.className || '';
         if (data.length) {
-            currentPage.cssClass = data + ' ' + device;
+            currentPage.className = data + ' ' + device;
         } else {
-            currentPage.cssClass = device;
+            currentPage.className = device;
         }
     }
 };


### PR DESCRIPTION
Tested locally, this seems to resolve all the issues I think are from https://github.com/NathanaelA/nativescript-platform-css/issues/4

Question though is do you version bump the min NS platform (I say yes! 🗡 )