### PR TITLE
Fix flickering because of reapplying styles with platform classes on modals

### DIFF
--- a/src/platformcss.js
+++ b/src/platformcss.js
@@ -91,7 +91,7 @@ const setDevice = function(args) {
 
 // Setup Events
 Page.on(Page.navigatingToFirst, setDevice);
-Page.on(Page.shownModallyFirst, setDevice);
+Page.on(Page.showingModallyFirst, setDevice);
 
 exports.sizeGroupings = function(val) {
 	if (Array.isArray(val)) {


### PR DESCRIPTION
Currently, because of applying classes for a modal page on `shownModallyFirst` event we got styles reapplying after page displayed to the user, and this cause flickering of content on a page (especially if you change paddings and margins). To fix this issue platform-css must be appalling to modals on `showingModallyFirst` event.